### PR TITLE
Glossary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .ipynb_checkpoints
 venv*
 jupyter_execute
+/content/.auctex-auto/
+/content/__pycache__/

--- a/content/bibliography.bib
+++ b/content/bibliography.bib
@@ -1,0 +1,26 @@
+@BOOK{Gropp2014-dz,
+  title     = "{Using Advanced MPI: Modern Features of the Message-Passing
+               Interface}",
+  author    = "Gropp, William and Hoefler, Torsten and Thakur, Rajeev and Lusk,
+               Ewing",
+  publisher = "MIT Press",
+  series    = "Scientific and Engineering Computation",
+  month     =  nov,
+  year      =  2014,
+  url       = "https://mitpress.mit.edu/books/using-advanced-mpi",
+  language  = "en",
+  isbn      = "9780262527637"
+}
+
+@BOOK{Gropp2014-qf,
+  title     = "{Using MPI: Portable Parallel Programming with the
+               Message-Passing Interface}",
+  author    = "Gropp, William and Lusk, Ewing and Skjellum, Anthony",
+  publisher = "MIT Press",
+  series    = "Scientific and Engineering Computation",
+  month     =  nov,
+  year      =  2014,
+  url       = "https://mitpress.mit.edu/books/using-mpi-third-edition",
+  language  = "en",
+  isbn      = "9780262527392"
+}

--- a/content/bibliography.rst
+++ b/content/bibliography.rst
@@ -1,0 +1,4 @@
+Bibliography
+------------
+
+.. bibliography:: bibliography.bib

--- a/content/communicators-groups.rst
+++ b/content/communicators-groups.rst
@@ -7,13 +7,8 @@ Communicators and groups
 
 .. objectives::
 
-   - Learn how to create communicators by splitting with |term-MPI_Comm_split|
-
-
-.. figure:: img/ENCCS.jpg
-   :class: with-border
-
-   This is the caption.
+   - Learn the difference between :term:`intracommunicator` and :term:`intercommunicator`.
+   - Learn how to create communicators by splitting with |term-MPI_Comm_split|.
 
 
 Topic introduction here

--- a/content/communicators-groups.rst
+++ b/content/communicators-groups.rst
@@ -7,7 +7,7 @@ Communicators and groups
 
 .. objectives::
 
-   - TODO
+   - Learn how to create communicators by splitting with |term-MPI_Comm_split|
 
 
 .. figure:: img/ENCCS.jpg

--- a/content/conf.py
+++ b/content/conf.py
@@ -12,19 +12,20 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('.'))
 
-from custom import rst_epilog
+sys.path.insert(0, os.path.abspath("."))
+
+from custom import MPI_glossary
 
 # -- Project information -----------------------------------------------------
 
-project = 'Intermediate MPI'
-copyright = '2020, EuroCC National Competence Centre Sweden'
-author = 'Mark Abraham, Roberto Di Remigio, Kjartan Thor Wikfeldt'
-github_user = 'ENCCS'
-github_repo_name = 'intermediate-mpi'  # auto-detected from dirname if blank
-github_version = 'master'
-conf_py_path = '/content/' # with leading and trailing slash
+project = "Intermediate MPI"
+copyright = "2020, EuroCC National Competence Centre Sweden"
+author = "Mark Abraham, Roberto Di Remigio, Kjartan Thor Wikfeldt"
+github_user = "ENCCS"
+github_repo_name = "intermediate-mpi"  # auto-detected from dirname if blank
+github_version = "master"
+conf_py_path = "/content/"  # with leading and trailing slash
 
 # -- General configuration ---------------------------------------------------
 
@@ -33,28 +34,35 @@ conf_py_path = '/content/' # with leading and trailing slash
 # ones.
 extensions = [
     # githubpages just adds a .nojekyll file
-    'sphinx.ext.githubpages',
-    'sphinx_lesson',
+    "sphinx.ext.githubpages",
+    "sphinx_lesson",
     # remove once sphinx_rtd_theme updated for contrast and accessibility:
-    'sphinx_rtd_theme_ext_color_contrast',
+    "sphinx_rtd_theme_ext_color_contrast",
     #'sphinx.ext.intersphinx',
+    "sphinxcontrib.bibtex",
 ]
 
 # Settings for myst_nb:
 # https://myst-nb.readthedocs.io/en/latest/use/execute.html#triggering-notebook-execution
-#jupyter_execute_notebooks = "off"
-#jupyter_execute_notebooks = "auto"   # *only* execute if at least one output is missing.
-#jupyter_execute_notebooks = "force"
+# jupyter_execute_notebooks = "off"
+# jupyter_execute_notebooks = "auto"   # *only* execute if at least one output is missing.
+# jupyter_execute_notebooks = "force"
 jupyter_execute_notebooks = "cache"
 
 # Add any paths that contain templates here, relative to this directory.
-#templates_path = ['_templates']
+# templates_path = ['_templates']
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['README*', '_build', 'Thumbs.db', '.DS_Store',
-                    'jupyter_execute', '*venv*']
+exclude_patterns = [
+    "README*",
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    "jupyter_execute",
+    "*venv*",
+]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -62,34 +70,38 @@ exclude_patterns = ['README*', '_build', 'Thumbs.db', '.DS_Store',
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
-html_logo = 'img/ENCCS.jpg'
+html_theme = "sphinx_rtd_theme"
+html_logo = "img/ENCCS.jpg"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+# html_static_path = ['_static']
 
 
 # HTML context:
 from os.path import dirname, realpath, basename
-html_context = {'display_github': True,
-                'github_user': github_user,
-                # Auto-detect directory name.  This can break, but
-                # useful as a default.
-                'github_repo': github_repo_name or basename(dirname(realpath(__file__))),
-                'github_version': github_version,
-                'conf_py_path': conf_py_path,
-               }
+
+html_context = {
+    "display_github": True,
+    "github_user": github_user,
+    # Auto-detect directory name.  This can break, but
+    # useful as a default.
+    "github_repo": github_repo_name or basename(dirname(realpath(__file__))),
+    "github_version": github_version,
+    "conf_py_path": conf_py_path,
+}
 
 # Intersphinx mapping.  For example, with this you can use
 # :py:mod:`multiprocessing` to link straight to the Python docs of that module.
 # List all available references:
 #   python -msphinx.ext.intersphinx https://docs.python.org/3/objects.inv
-#intersphinx_mapping = {
+# intersphinx_mapping = {
 #    #'python': ('https://docs.python.org/3', None),
 #    #'sphinx': ('https://www.sphinx-doc.org/', None),
 #    }
 
 # the epilog
-rst_epilog = rst_epilog()
+rst_epilog = f"""
+{MPI_glossary()}
+"""

--- a/content/conf.py
+++ b/content/conf.py
@@ -10,10 +10,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
 
+from custom import rst_epilog
 
 # -- Project information -----------------------------------------------------
 
@@ -90,37 +91,5 @@ html_context = {'display_github': True,
 #    #'sphinx': ('https://www.sphinx-doc.org/', None),
 #    }
 
-
-# add the MPI function to reference in the glossary here. This skullduggery is
-# necessary to get consistent monospace formatting of the function
-MPI_functions = [
-    "MPI_Comm_split",
-]
-
-abbr_and_term = """
-.. |{function}| replace:: ``{function}``
-.. |term-{function}| raw:: html
-
-   <a class="reference internal" href="quick-reference.html#term-{function}"><span class="xref std std-term"><code class="docutils literal notranslate">{function}</code></span></a>
-"""
-
-impls = """
-.. |{function}-implementors_docs| raw:: html
-
-   <p>Documentation from implementors:</p>
-   <blockquote>
-   <div><ul class="simple">
-   <li><p><a class="reference external" href="https://www.mpich.org/static/docs/latest/www3/{function}.html">MPICH</a></p></li>
-   <li><p><a class="reference external" href="https://www.open-mpi.org/doc/current/man3/{function}.3.php">OpenMPI</a></p></li>
-   </ul>
-   </div></blockquote>
-"""
-
-# abbreviations and terms for the glossary
-glossary_helper = "\n".join([abbr_and_term.format(function=f) for f in MPI_functions])
-
-# documentation string from implementors
-implementors_docs = "\n".join([impls.format(function=f) for f in MPI_functions])
-
-# include all customisation in the rst_epilog, so it's available everywhere
-rst_epilog = glossary_helper + implementors_docs
+# the epilog
+rst_epilog = rst_epilog()

--- a/content/conf.py
+++ b/content/conf.py
@@ -89,3 +89,38 @@ html_context = {'display_github': True,
 #    #'python': ('https://docs.python.org/3', None),
 #    #'sphinx': ('https://www.sphinx-doc.org/', None),
 #    }
+
+
+# add the MPI function to reference in the glossary here. This skullduggery is
+# necessary to get consistent monospace formatting of the function
+MPI_functions = [
+    "MPI_Comm_split",
+]
+
+abbr_and_term = """
+.. |{function}| replace:: ``{function}``
+.. |term-{function}| raw:: html
+
+   <a class="reference internal" href="quick-reference.html#term-{function}"><span class="xref std std-term"><code class="docutils literal notranslate">{function}</code></span></a>
+"""
+
+impls = """
+.. |{function}-implementors_docs| raw:: html
+
+   <p>Documentation from implementors:</p>
+   <blockquote>
+   <div><ul class="simple">
+   <li><p><a class="reference external" href="https://www.mpich.org/static/docs/latest/www3/{function}.html">MPICH</a></p></li>
+   <li><p><a class="reference external" href="https://www.open-mpi.org/doc/current/man3/{function}.3.php">OpenMPI</a></p></li>
+   </ul>
+   </div></blockquote>
+"""
+
+# abbreviations and terms for the glossary
+glossary_helper = "\n".join([abbr_and_term.format(function=f) for f in MPI_functions])
+
+# documentation string from implementors
+implementors_docs = "\n".join([impls.format(function=f) for f in MPI_functions])
+
+# include all customisation in the rst_epilog, so it's available everywhere
+rst_epilog = glossary_helper + implementors_docs

--- a/content/custom.py
+++ b/content/custom.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*# -*- coding: utf-8 -*-
+
+# add the MPI function to reference in the glossary here. This skullduggery is
+# necessary to get consistent monospace formatting of the function
+MPI_functions = [
+    "MPI_Comm_split",
+    "MPI_Get",
+    "MPI_Put",
+    "MPI_Accumulate",
+    "MPI_Win_create",
+    "MPI_Win_allocate",
+    "MPI_Win_allocate_shared",
+    "MPI_Win_create_dynamic",
+    "MPI_Win_fence",
+    "MPI_Win_post",
+    "MPI_Win_start",
+    "MPI_Win_complete",
+    "MPI_Win_wait",
+    "MPI_Win_lock",
+    "MPI_Win_unlock",
+]
+
+abbr_and_term = """
+.. |{function}| replace:: ``{function}``
+.. |term-{function}| raw:: html
+
+   <a class="reference internal" href="quick-reference.html#term-{function}"><span class="xref std std-term"><code class="docutils literal notranslate">{function}</code></span></a>
+"""
+
+impls = """
+.. |{function}-implementors_docs| raw:: html
+
+   <p>Documentation from implementors:</p>
+   <blockquote>
+   <div><ul class="simple">
+   <li><p><a class="reference external" href="https://www.mpich.org/static/docs/latest/www3/{function}.html">MPICH</a></p></li>
+   <li><p><a class="reference external" href="https://www.open-mpi.org/doc/current/man3/{function}.3.php">OpenMPI</a></p></li>
+   </ul>
+   </div></blockquote>
+"""
+
+def rst_epilog():
+    # abbreviations and terms for the glossary
+    glossary_helper = "\n".join([abbr_and_term.format(function=f) for f in MPI_functions])
+
+    # documentation string from implementors
+    implementors_docs = "\n".join([impls.format(function=f) for f in MPI_functions])
+
+    # include all customisation in the rst_epilog, so it's available everywhere
+    return glossary_helper + implementors_docs

--- a/content/custom.py
+++ b/content/custom.py
@@ -1,9 +1,23 @@
-# -*- coding: utf-8 -*# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 # add the MPI function to reference in the glossary here. This skullduggery is
 # necessary to get consistent monospace formatting of the function
-MPI_functions = [
+# Communicators and groups
+lesson_comms = [
     "MPI_Comm_split",
+]
+# derived datatypes
+lesson_dd = [
+    "MPI_Pack",
+    "MPI_Unpack",
+    "MPI_Type_create_struct",
+    "MPI_Type_commit",
+    "MPI_Type_contiguous",
+    "MPI_Type_vector",
+    "MPI_Type_indexed",
+]
+# remote memory access
+lesson_rma = [
     "MPI_Get",
     "MPI_Put",
     "MPI_Accumulate",
@@ -19,6 +33,12 @@ MPI_functions = [
     "MPI_Win_lock",
     "MPI_Win_unlock",
 ]
+# collectives
+lesson_coll = []
+# threads
+lesson_threads = []
+
+MPI_functions = lesson_comms + lesson_dd + lesson_rma + lesson_coll + lesson_threads
 
 abbr_and_term = """
 .. |{function}| replace:: ``{function}``
@@ -39,9 +59,12 @@ impls = """
    </div></blockquote>
 """
 
-def rst_epilog():
+
+def MPI_glossary():
     # abbreviations and terms for the glossary
-    glossary_helper = "\n".join([abbr_and_term.format(function=f) for f in MPI_functions])
+    glossary_helper = "\n".join(
+        [abbr_and_term.format(function=f) for f in MPI_functions]
+    )
 
     # documentation string from implementors
     implementors_docs = "\n".join([impls.format(function=f) for f in MPI_functions])

--- a/content/derived-datatypes.rst
+++ b/content/derived-datatypes.rst
@@ -3,11 +3,15 @@ Derived datatypes
 
 .. questions::
 
-   - TODO
+   - How can you reduce the number of messages sent and received?
+   - How can you use your own derived datatypes as content of messages?
 
 .. objectives::
 
-   - TODO
+   - Understand how MPI handles datatypes and the :term:`typemap` concept.
+   - Learn to send and receive composite messages with |term-MPI_Pack| and |term-MPI_Unpack|
+   - Learn how to represent your own derived datatypes as MPI messages with |term-MPI_Type_create_struct| and |term-MPI_Type_commit|
+   - Learn how to represent homogeneous collections as MPI messages. |term-MPI_Type_contiguous|, |term-MPI_Type_vector|, |term-MPI_Type_indexed|
 
 
 .. figure:: img/ENCCS.jpg
@@ -23,26 +27,14 @@ how this is implemented.  See the links at the to right of the page.
 
 
 
-This is a section
------------------
+Representation of datatypes in MPI
+----------------------------------
 
-This is text.
+- Typemaps
+- Type signature
+- Lower bounds, upper bounds, extents
 
-A code block with preceeding paragraph::
-
-  import multiprocessing
-
-* A bullet list
-
-* Bullet list
-
-  * Sub-list::
-
-      code block (note indention)
-
-  .. note::
-
-     directive within a list (note indention)
+:cite:`Gropp2014-qf`
 
 
 Exercise: the general topic

--- a/content/index.rst
+++ b/content/index.rst
@@ -45,6 +45,7 @@ TODO Intro
    :caption: Reference
 
    quick-reference
+   bibliography
    guide
 
 

--- a/content/one-sided-pt1.rst
+++ b/content/one-sided-pt1.rst
@@ -3,17 +3,15 @@ One-sided communication 1
 
 .. questions::
 
-   - TODO
+   - How can we optimize communication?
 
 .. objectives::
 
-   - TODO
-
-
-.. figure:: img/ENCCS.jpg
-   :class: with-border
-
-   This is the caption.
+   - Learn about functions for remote-memory access (RMA)
+   - RMA: |term-MPI_Get|, |term-MPI_Put|, |term-MPI_Accumulate|
+   - Windows: |term-MPI_Win_create|, |term-MPI_Win_allocate|, |term-MPI_Win_allocate_shared|, |term-MPI_Win_create_dynamic|
+   - Active synchronization: |term-MPI_Win_fence|, |term-MPI_Win_post|, |term-MPI_Win_start|, |term-MPI_Win_complete|, |term-MPI_Win_wait|
+   - Passive synchronization: |term-MPI_Win_lock|, |term-MPI_win_unlock|
 
 
 Topic introduction here

--- a/content/quick-reference.rst
+++ b/content/quick-reference.rst
@@ -18,6 +18,16 @@ Quick Reference
    synchronization
       The necessary coordination of remote memory accesses. It can be *active* or *passive*.
 
+   typemap
+      Abstraction used to represent a datatypes in MPI. It is an associative
+      array (map) with datatypes, as understood by MPI, as *keys* and
+      displacements, in bytes, as *values*. The displacements are computed
+      relative to the buffer the datatype describes.
+
+      .. math::
+
+         \textrm{Typemap} = \{ \textrm{Datatype}_{0}: \textrm{Displacement}_{0}, \ldots, \textrm{Datatype}_{n-1}: \textrm{Displacement}_{n-1} \}
+
 MPI functions
 ^^^^^^^^^^^^^
 
@@ -34,6 +44,96 @@ MPI functions
                             MPI_Comm *newcomm)
 
       |MPI_Comm_split-implementors_docs|
+
+   ``MPI_Pack``
+       Pack data in a message. The message is in contiguous memory.
+
+       .. code-block:: c
+
+          int MPI_Pack(const void *inbuf,
+                       int incount,
+                       MPI_Datatype datatype,
+                       void *outbuf,
+                       int outsize,
+                       int *position,
+                       MPI_Comm comm)
+
+       |MPI_Pack-implementors_docs|
+
+   ``MPI_Unpack``
+       Unpack a message to data in contiguous memory.
+
+       .. code-block:: c
+
+          int MPI_Unpack(const void *inbuf,
+                         int insize,
+                         int *position,
+                         void *outbuf,
+                         int outcount,
+                         MPI_Datatype datatype,
+                         MPI_Comm comm)
+
+       |MPI_Unpack-implementors_docs|
+
+   ``MPI_Type_create_struct``
+       Foo
+       This function replaces the *deprecated* ``MPI_Type_struct``.
+
+       .. code-block:: c
+
+          int MPI_Type_create_struct(int count,
+                                     const int array_of_block_lengths[],
+                                     const MPI_Aint array_of_displacements[],
+                                     const MPI_Datatype array_of_types[],
+                                     MPI_Datatype *newtype)
+
+       |MPI_Type_create_struct-implementors_docs|
+
+   ``MPI_Type_commit``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Type_commit(MPI_Datatype *datatype)
+
+       |MPI_Type_commit-implementors_docs|
+
+   ``MPI_Type_contiguous``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Type_contiguous(int count,
+                                  MPI_Datatype oldtype,
+                                  MPI_Datatype *newtype)
+
+       |MPI_Type_contiguous-implementors_docs|
+
+   ``MPI_Type_vector``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Type_vector(int count,
+                              int blocklength,
+                              int stride,
+                              MPI_Datatype oldtype,
+                              MPI_Datatype *newtype)
+
+       |MPI_Type_vector-implementors_docs|
+
+   ``MPI_Type_indexed``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Type_indexed(int count,
+                               const int array_of_blocklengths[],
+                               const int array_of_displacements[],
+                               MPI_Datatype oldtype,
+                               MPI_Datatype *newtype)
+
+       |MPI_Type_indexed-implementors_docs|
 
    ``MPI_Get``
        Load data from a remote memory window.

--- a/content/quick-reference.rst
+++ b/content/quick-reference.rst
@@ -3,8 +3,28 @@ Quick Reference
 
 .. glossary::
 
+
+   intracommunicator
+      Foo
+
+   intercommunicator
+      Foo
+
+   window
+   memory window
+   remote memory window
+      Process-local memory allocated for remote memory access operations. It is of implementation-dependent type ``MPI_Win``.
+
+   synchronization
+      The necessary coordination of remote memory accesses. It can be *active* or *passive*.
+
+MPI functions
+^^^^^^^^^^^^^
+
+.. glossary::
+
    ``MPI_Comm_split``
-      Function to split an existing communicator.
+      Split an existing communicator.
 
       .. code-block:: c
 
@@ -14,3 +34,177 @@ Quick Reference
                             MPI_Comm *newcomm)
 
       |MPI_Comm_split-implementors_docs|
+
+   ``MPI_Get``
+       Load data from a remote memory window.
+
+       .. code-block:: c
+
+          int MPI_Get(void *origin_addr,
+                      int origin_count,
+                      MPI_Datatype origin_datatype,
+                      int target_rank,
+                      MPI_Aint target_disp,
+                      int target_count,
+                      MPI_Datatype target_datatype,
+                      MPI_Win win)
+
+       |MPI_Get-implementors_docs|
+
+   ``MPI_Put``
+       Store data to a remote memory window.
+
+       .. code-block:: c
+
+          int MPI_Put(const void *origin_addr,
+                      int origin_count,
+                      MPI_Datatype origin_datatype,
+                      int target_rank,
+                      MPI_Aint target_disp,
+                      int target_count,
+                      MPI_Datatype target_datatype,
+                      MPI_Win win)
+
+       |MPI_Put-implementors_docs|
+
+   ``MPI_Accumulate``
+       Accumulate data into target process through remote memory access.
+
+       .. code-block:: c
+
+          int MPI_Accumulate(const void *origin_addr,
+                             int origin_count,
+                             MPI_Datatype origin_datatype,
+                             int target_rank,
+                             MPI_Aint target_disp,
+                             int target_count,
+                             MPI_Datatype target_datatype,
+                             MPI_Op op,
+                             MPI_Win win)
+
+       |MPI_Accumulate-implementors_docs|
+
+   ``MPI_Win_create``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Win_create(void *base,
+                             MPI_Aint size,
+                             int disp_unit,
+                             MPI_Info info,
+                             MPI_Comm comm,
+                             MPI_Win *win)
+
+       |MPI_Win_create-implementors_docs|
+
+   ``MPI_Win_allocate``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Win_allocate(MPI_Aint size,
+                               int disp_unit,
+                               MPI_Info info,
+                               MPI_Comm comm,
+                               void *baseptr,
+                               MPI_Win *win)
+
+       |MPI_Win_allocate-implementors_docs|
+
+   ``MPI_Win_allocate_shared``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Win_allocate_shared(MPI_Aint size,
+                                      int disp_unit,
+                                      MPI_Info info,
+                                      MPI_Comm comm,
+                                      void *baseptr,
+                                      MPI_Win *win)
+
+       |MPI_Win_allocate_shared-implementors_docs|
+
+   ``MPI_Win_create_dynamic``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Win_create_dynamic(MPI_Info info,
+                                     MPI_Comm comm,
+                                     MPI_Win *win)
+
+       |MPI_Win_create_dynamic-implementors_docs|
+
+   ``MPI_Win_fence``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Win_fence(int assert,
+                            MPI_Win win)
+
+       |MPI_Win_fence-implementors_docs|
+
+   ``MPI_Win_post``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Win_post(MPI_Group group,
+                           int assert,
+                           MPI_Win win)
+
+       |MPI_Win_post-implementors_docs|
+
+   ``MPI_Win_start``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Win_start(MPI_Group group,
+                            int assert,
+                            MPI_Win win)
+
+       |MPI_Win_start-implementors_docs|
+
+   ``MPI_Win_complete``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Win_complete(MPI_Win win)
+
+       |MPI_Win_complete-implementors_docs|
+
+   ``MPI_Win_wait``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Win_wait(MPI_Win win)
+
+       |MPI_Win_wait-implementors_docs|
+
+   ``MPI_Win_lock``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Win_lock(int lock_type,
+                           int rank,
+                           int assert,
+                           MPI_Win win)
+
+       |MPI_Win_lock-implementors_docs|
+
+   ``MPI_Win_unlock``
+       Foo
+
+       .. code-block:: c
+
+          int MPI_Win_unlock(int rank,
+                             MPI_Win win)
+
+       |MPI_Win_unlock-implementors_docs|

--- a/content/quick-reference.rst
+++ b/content/quick-reference.rst
@@ -1,2 +1,16 @@
 Quick Reference
 ---------------
+
+.. glossary::
+
+   ``MPI_Comm_split``
+      Function to split an existing communicator.
+
+      .. code-block:: c
+
+         int MPI_Comm_split(MPI_Comm comm,
+                            int color,
+                            int key,
+                            MPI_Comm *newcomm)
+
+      |MPI_Comm_split-implementors_docs|

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx_rtd_theme
 sphinx_rtd_theme_ext_color_contrast
 myst_nb
 sphinx-lesson
+sphinxcontrib-bibtex


### PR DESCRIPTION
I'm outlining the "communicators and groups" and "derived datatypes" episodes and modified some infrastructure to get a proper glossary working. This is achieved with rst  *substitutions* to raw HTML (there is no way around it for this use case, _i.e._ preserving the monospace inline markup)

The glossary contains a list of the MPI functions in each episode with the C signature and links to the OpenMPI and MPICH  documentation pages.

![Screenshot from 2020-11-16 16-59-48](https://user-images.githubusercontent.com/3708689/99276666-2ab3d500-282d-11eb-91ab-63c4d0a5c282.png)

Assuming you want to add the function `MPI_<function>` to the glossary:
- Edit `custom.py` and add the name of your function to the list for the relevant episode. When generating the HTML, the substitutions `|MPI_<function>-implementors_docs|` and `|term-MPI_<function>|` will be generated too.
- Add an item in `quick-reference.rst`  following this template:
```rst
   ``MPI_<function>``
      ADD A ONE-SENTENCE DESCRIPTION

      .. code-block:: c

         FILL THE SIGNATURE
    
      |MPI_<function>-implementors_docs|
```
- You can refer to this item in the text by using `|term-MPI_<function>|`.