### PR TITLE
.github/workflows/sphinx: Fix sphinx-copybutton icon being wrong

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Build Sphinx docs
         run: |
           make dirhtml
+          sed -i 's/url_root="#"/url_root=""/' _build/dirhtml/index.html || true
 
 
       # The following supports building all branches and combining on


### PR DESCRIPTION
- Fixes missing icons of the copy button, causing bad-apperances as
  documented in
  https://github.com/executablebooks/sphinx-copybutton/issues/110
- This is a workaround until upstream can fix the themes.  This should
  work in most cases.  It could fail if a document includes the exact
  string `url_root="#"`, but I'm willing to assume that wont' happen
  for now...
- Review: check if it builds properly